### PR TITLE
Flag in-source fragments and re-inject for quantification (--flag_in_source)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- Added `--flag_in_source` to flag in-source fragments (`is_isf` UserParam) and re-inject them into the FDR-filtered set so their signal reaches quantification [#XXX](https://github.com/nf-core/mhcquant/pull/XXX)
+- Added `--flag_in_source` to flag in-source fragments (`is_isf` UserParam) and re-inject them into the FDR-filtered set so their signal reaches quantification [#3](https://github.com/jonasscheid/mhcquant/pull/3)
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.3.0dev
 
+### `Added`
+
+- Added `--flag_in_source` to flag in-source fragments (`is_isf` UserParam) and re-inject them into the FDR-filtered set so their signal reaches quantification [#XXX](https://github.com/nf-core/mhcquant/pull/XXX)
+
 ### `Changed`
 
 - Updated to nf-core template 4.0.2 [#454](https://github.com/nf-core/mhcquant/pull/454)

--- a/bin/flag_in_source_fragments.py
+++ b/bin/flag_in_source_fragments.py
@@ -220,40 +220,45 @@ def main(argv=None):
     parent_index_by_run = {run: build_parent_index(ps, args.min_len)
                            for run, ps in parents_by_run.items()}
 
-    # Walk rescored identifications once. Annotate is_isf on EVERY rescored PSM (so the flag
-    # survives into quantification, which rips/quantifies from the rescored runs), and collect
-    # the augmented filtered subset (filtered hits + flagged ISF candidates) used as the
-    # whitelist / identification export.
-    rescored_out = []
-    filtered_out = []
-    n_isf = n_isf_subthreshold = 0
+    # Pass 1 — per-PSM (per-run) flagging. Record, for every rank-1 hit, its peptidoform
+    # (modified sequence), origin-run identity, and whether it is in the filtered set; collect the
+    # set of flagged peptidoforms (peptidoform -> matched parent sequence).
+    psms = []                      # (pid, peptidoform, in_filtered)
+    flagged_peptidoforms = {}      # peptidoform -> isf_parent_sequence
     for pid in resc_pids:
         rec = best_hit_record(pid, resolve_run(pid, resc_sd))
         if rec is None:
             continue
+        peptidoform = pid.getHits()[0].getSequence().toString()
         in_filtered = rec["key"] in filtered_keys
-        isf_parent = None
         if rec["target_decoy"] != "decoy":
-            isf_parent = flag_candidate(rec, parent_index_by_run.get(rec["run"], {}),
-                                        args.delta_obs, delta_pred, args.min_len)
-        is_isf = isf_parent is not None
-        # annotate the rank-1 hit and persist
+            parent = flag_candidate(rec, parent_index_by_run.get(rec["run"], {}),
+                                    args.delta_obs, delta_pred, args.min_len)
+            if parent is not None:
+                flagged_peptidoforms.setdefault(peptidoform, parent["sequence"])
+        psms.append((pid, peptidoform, in_filtered))
+
+    # Pass 2 — propagate the flag to the PEPTIDOFORM level. A peptidoform flagged in any run is an
+    # in-source fragment everywhere, so we annotate every PSM of it. This is what makes the flag
+    # survive quantification: QUANT picks one representative PSM per peptidoform in the consensus,
+    # and a per-PSM flag would be lost whenever the representative came from an unflagged run.
+    rescored_out = []
+    filtered_out = []
+    for pid, peptidoform, in_filtered in psms:
+        is_isf = peptidoform in flagged_peptidoforms
         hits = pid.getHits()
         hits[0].setMetaValue("is_isf", "true" if is_isf else "false")
         if is_isf:
-            hits[0].setMetaValue("isf_parent_sequence", isf_parent["sequence"])
+            hits[0].setMetaValue("isf_parent_sequence", flagged_peptidoforms[peptidoform])
         pid.setHits(hits)
         rescored_out.append(pid)
         if in_filtered or is_isf:
             filtered_out.append(pid)
-        if is_isf:
-            n_isf += 1
-            if not in_filtered:
-                n_isf_subthreshold += 1
 
-    log.info("is_isf=true: %d (of which %d sub-threshold appended to filtered); "
+    n_isf_psms = sum(1 for _, pf, _ in psms if pf in flagged_peptidoforms)
+    log.info("flagged peptidoforms: %d | is_isf=true PSMs (peptidoform-propagated): %d | "
              "filtered out=%d, rescored out=%d",
-             n_isf, n_isf_subthreshold, len(filtered_out), len(rescored_out))
+             len(flagged_peptidoforms), n_isf_psms, len(filtered_out), len(rescored_out))
 
     # Use the rescored ProteinIdentification (superset) so all protein_refs resolve.
     oms.IdXMLFile().store(args.out, resc_prot, filtered_out)

--- a/bin/flag_in_source_fragments.py
+++ b/bin/flag_in_source_fragments.py
@@ -168,9 +168,9 @@ def build_parent_index(parents, min_len):
     return index
 
 
-def flag_candidate(cand, parent_index, delta_obs, delta_pred):
+def flag_candidate(cand, parent_index, delta_obs, delta_pred, min_len):
     """Return the best matching parent dict if cand is an ISF, else None."""
-    if (cand["sequence"] is None or len(cand["sequence"]) < MIN_OVERLAP_LEN
+    if (cand["sequence"] is None or len(cand["sequence"]) < min_len
             or cand["rt_obs"] is None or cand["rt_pred"] is None):
         return None
     candidates = parent_index.get(cand["sequence"])
@@ -235,7 +235,7 @@ def main(argv=None):
         isf_parent = None
         if rec["target_decoy"] != "decoy":
             isf_parent = flag_candidate(rec, parent_index_by_run.get(rec["run"], {}),
-                                        args.delta_obs, delta_pred)
+                                        args.delta_obs, delta_pred, args.min_len)
         is_isf = isf_parent is not None
         # annotate the rank-1 hit and persist
         hits = pid.getHits()

--- a/bin/flag_in_source_fragments.py
+++ b/bin/flag_in_source_fragments.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python
+"""Flag in-source fragments (ISF) in rescored MHCquant identifications.
+
+In-source dissociation cleaves intact peptides in the ESI source before MS2 isolation. The
+resulting b/y-type truncations co-elute with their intact parent but a sequence-based RT
+predictor (DeepLC) predicts them to elute elsewhere. This script reads the FDR-filtered idXML
+(the confident parents) and the 100% FDR rescored idXML (the ISF candidate source), tags every
+output PeptideHit with an ``is_isf`` UserParam, and appends the flagged ISF candidates to the
+filtered set so they reach quantification.
+
+Matching is done per origin run (``id_merge_index``); RT is only comparable within a run.
+
+Usage:
+    flag_in_source_fragments.py --filtered <fdr_filtered.idXML> \
+        --rescored <pout.idXML> --out <out.idXML>
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import numpy as np
+import pyopenms as oms
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+log = logging.getLogger("flag_isf")
+
+# Hardcoded detection defaults (not user-facing; see design spec).
+MIN_OVERLAP_LEN = 6        # minimum fragment length to consider
+DELTA_OBS_TOL = 5.0        # s, co-elution tolerance (observed RT)
+PRED_TOL_PERCENTILE = 95.0  # percentile of parent DeepLC residuals -> Δpred tolerance
+PRED_TOL_FLOOR = 60.0      # s, fallback Δpred tolerance when too few parents
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description="Flag in-source fragments in rescored idXML.")
+    p.add_argument("--filtered", required=True, help="FDR-filtered idXML (confident parents)")
+    p.add_argument("--rescored", required=True, help="100%% FDR rescored idXML (ISF candidates)")
+    p.add_argument("--out", required=True,
+                   help="output filtered idXML (whitelist + ID export): filtered hits + flagged ISF")
+    p.add_argument("--out-rescored", default=None,
+                   help="output rescored idXML with is_isf annotated on every PSM (fed to "
+                        "quantification so the flag reaches the final table)")
+    p.add_argument("--min-len", type=int, default=MIN_OVERLAP_LEN)
+    p.add_argument("--delta-obs", type=float, default=DELTA_OBS_TOL)
+    p.add_argument("--delta-pred", type=float, default=None,
+                   help="Δpredicted-RT tolerance in s (default: data-driven per run)")
+    p.add_argument("--pred-percentile", type=float, default=PRED_TOL_PERCENTILE)
+    return p.parse_args(argv)
+
+
+def load_idxml(path):
+    prot_ids, pep_ids = [], []
+    oms.IdXMLFile().load(path, prot_ids, pep_ids)
+    return prot_ids, pep_ids
+
+
+def spectrum_ref(pid):
+    try:
+        ref = pid.getSpectrumReference()
+        if ref:
+            return ref
+    except Exception:
+        pass
+    if pid.metaValueExists("spectrum_reference"):
+        return pid.getMetaValue("spectrum_reference")
+    return None
+
+
+def spectra_data_map(prot_ids):
+    """Map each ProteinIdentification identifier -> list of run names (spectra_data basenames).
+
+    The merged idXML stores the ordered list of source runs as the `spectra_data` MetaValue on
+    the ProteinIdentification; each PeptideIdentification points into it via `id_merge_index`.
+    """
+    out = {}
+    for pr in prot_ids:
+        runs = []
+        if pr.metaValueExists("spectra_data"):
+            for s in pr.getMetaValue("spectra_data"):
+                s = s.decode() if isinstance(s, (bytes, bytearray)) else str(s)
+                runs.append(os.path.basename(s))
+        out[pr.getIdentifier()] = runs
+    return out
+
+
+def resolve_run(pid, sd_map):
+    """Resolve the origin run NAME of a PeptideIdentification via spectra_data[id_merge_index].
+
+    Using the run name (not the raw index) makes parent/candidate matching robust even if the
+    two idXMLs order their spectra_data differently.
+    """
+    runs = sd_map.get(pid.getIdentifier(), [])
+    if pid.metaValueExists("id_merge_index"):
+        idx = int(pid.getMetaValue("id_merge_index"))
+        if 0 <= idx < len(runs):
+            return runs[idx]
+        return "idx%d" % idx
+    return runs[0] if runs else "run0"
+
+
+def _meta_float(hit, key):
+    if hit.metaValueExists(key):
+        try:
+            return float(hit.getMetaValue(key))
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def best_hit_record(pid, run_name):
+    """Return a dict describing the rank-1 hit of a PeptideIdentification, or None.
+
+    Matching is strictly per origin run: ``run_name`` is the scope for RT comparison and part
+    of the unique identity key.
+    """
+    hits = pid.getHits()
+    if not hits:
+        return None
+    h = hits[0]
+    seq = h.getSequence().toUnmodifiedString()
+    obs = _meta_float(h, "observed_retention_time_best")
+    if obs is None:
+        obs = pid.getRT()
+    sref = spectrum_ref(pid)
+    return {
+        "run": run_name,                    # origin run: scope for RT comparison
+        "key": (run_name, sref),            # identity: origin run + spectrum (unique)
+        "sequence": seq,
+        "rt_obs": obs,
+        "rt_pred": _meta_float(h, "predicted_retention_time_best"),
+        "rt_diff_best": _meta_float(h, "rt_diff_best"),
+        "target_decoy": h.getMetaValue("target_decoy") if h.metaValueExists("target_decoy") else "target",
+    }
+
+
+def terminal_substrings(seq, min_len):
+    """Yield every contiguous prefix/suffix of seq with length in [min_len, len(seq)-1]."""
+    n = len(seq)
+    for k in range(min_len, n):
+        yield seq[:k]
+        yield seq[n - k:]
+
+
+def is_prefix_or_suffix(parent_seq, frag_seq):
+    return (len(frag_seq) < len(parent_seq)
+            and (parent_seq.startswith(frag_seq) or parent_seq.endswith(frag_seq)))
+
+
+def derive_pred_tol(parents_by_run, percentile):
+    resid = [p["rt_diff_best"] for run in parents_by_run.values()
+             for p in run if p["rt_diff_best"] is not None]
+    if len(resid) >= 5:
+        return float(np.percentile(resid, percentile))
+    return PRED_TOL_FLOOR
+
+
+def build_parent_index(parents, min_len):
+    """Map each prefix/suffix of every parent (in one run) to the parent records."""
+    index = {}
+    for p in parents:
+        seq = p["sequence"]
+        if seq is None or len(seq) <= min_len or p["rt_obs"] is None or p["rt_pred"] is None:
+            continue
+        for sub in set(terminal_substrings(seq, min_len)):
+            index.setdefault(sub, []).append(p)
+    return index
+
+
+def flag_candidate(cand, parent_index, delta_obs, delta_pred):
+    """Return the best matching parent dict if cand is an ISF, else None."""
+    if (cand["sequence"] is None or len(cand["sequence"]) < MIN_OVERLAP_LEN
+            or cand["rt_obs"] is None or cand["rt_pred"] is None):
+        return None
+    candidates = parent_index.get(cand["sequence"])
+    if not candidates:
+        return None
+    best = None
+    for p in candidates:
+        if p["key"] == cand["key"]:
+            continue  # never match a PSM to itself
+        if not is_prefix_or_suffix(p["sequence"], cand["sequence"]):
+            continue
+        d_obs = cand["rt_obs"] - p["rt_obs"]
+        d_pred = cand["rt_pred"] - p["rt_pred"]
+        if abs(d_obs) <= delta_obs and abs(d_pred) >= delta_pred:
+            if best is None or abs(d_obs) < best[0]:
+                best = (abs(d_obs), p)
+    return best[1] if best else None
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    log.info("Loading filtered idXML (parents): %s", args.filtered)
+    filt_prot, filt_pids = load_idxml(args.filtered)
+    log.info("Loading rescored idXML (candidates): %s", args.rescored)
+    resc_prot, resc_pids = load_idxml(args.rescored)
+
+    filt_sd = spectra_data_map(filt_prot)
+    resc_sd = spectra_data_map(resc_prot)
+
+    # Parents (confident) grouped strictly per origin run; identity tracked by unique key.
+    parents_by_run = {}
+    filtered_keys = set()
+    for pid in filt_pids:
+        rec = best_hit_record(pid, resolve_run(pid, filt_sd))
+        if rec is None:
+            continue
+        filtered_keys.add(rec["key"])
+        if rec["target_decoy"] != "decoy":
+            parents_by_run.setdefault(rec["run"], []).append(rec)
+
+    delta_pred = args.delta_pred if args.delta_pred is not None \
+        else derive_pred_tol(parents_by_run, args.pred_percentile)
+    log.info("Parents: %d in %d run(s); delta_obs<=%.1fs, delta_pred>=%.1fs",
+             len(filtered_keys), len(parents_by_run), args.delta_obs, delta_pred)
+
+    parent_index_by_run = {run: build_parent_index(ps, args.min_len)
+                           for run, ps in parents_by_run.items()}
+
+    # Walk rescored identifications once. Annotate is_isf on EVERY rescored PSM (so the flag
+    # survives into quantification, which rips/quantifies from the rescored runs), and collect
+    # the augmented filtered subset (filtered hits + flagged ISF candidates) used as the
+    # whitelist / identification export.
+    rescored_out = []
+    filtered_out = []
+    n_isf = n_isf_subthreshold = 0
+    for pid in resc_pids:
+        rec = best_hit_record(pid, resolve_run(pid, resc_sd))
+        if rec is None:
+            continue
+        in_filtered = rec["key"] in filtered_keys
+        isf_parent = None
+        if rec["target_decoy"] != "decoy":
+            isf_parent = flag_candidate(rec, parent_index_by_run.get(rec["run"], {}),
+                                        args.delta_obs, delta_pred)
+        is_isf = isf_parent is not None
+        # annotate the rank-1 hit and persist
+        hits = pid.getHits()
+        hits[0].setMetaValue("is_isf", "true" if is_isf else "false")
+        if is_isf:
+            hits[0].setMetaValue("isf_parent_sequence", isf_parent["sequence"])
+        pid.setHits(hits)
+        rescored_out.append(pid)
+        if in_filtered or is_isf:
+            filtered_out.append(pid)
+        if is_isf:
+            n_isf += 1
+            if not in_filtered:
+                n_isf_subthreshold += 1
+
+    log.info("is_isf=true: %d (of which %d sub-threshold appended to filtered); "
+             "filtered out=%d, rescored out=%d",
+             n_isf, n_isf_subthreshold, len(filtered_out), len(rescored_out))
+
+    # Use the rescored ProteinIdentification (superset) so all protein_refs resolve.
+    oms.IdXMLFile().store(args.out, resc_prot, filtered_out)
+    log.info("Wrote filtered (whitelist + ID export): %s", args.out)
+    if args.out_rescored:
+        oms.IdXMLFile().store(args.out_rescored, resc_prot, rescored_out)
+        log.info("Wrote rescored (is_isf-annotated, for quantification): %s", args.out_rescored)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -169,6 +169,15 @@ process {
         ]
     }
 
+    withName: 'PYOPENMS_FLAGINSOURCE' {
+        ext.prefix  = {"${meta.id}"}
+        publishDir  = [
+            path: {"${params.outdir}/intermediate_results/rescoring"},
+            mode: params.publish_dir_mode,
+            pattern: '*.idXML'
+        ]
+    }
+
     withName: 'OPENMS_IDFILTER_Q_VALUE_GLOBAL' {
         label = 'process_high_memory'
         ext.prefix  = {"${meta.id}_pout_filtered"}
@@ -490,7 +499,8 @@ process {
                 "observed_retention_time_best", "predicted_retention_time_best",
                 "spec_pearson",
                 "std_abs_diff",
-                "ccs_predicted_im2deep", "ccs_error_im2deep", "ion_mobility"
+                "ccs_predicted_im2deep", "ccs_error_im2deep", "ion_mobility",
+                "is_isf"
             ].join(',').trim(),
         ].join(' ').trim()
         publishDir  = [

--- a/modules/local/pyopenms/flaginsource/environment.yml
+++ b/modules/local/pyopenms/flaginsource/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::pyopenms=3.4.1

--- a/modules/local/pyopenms/flaginsource/main.nf
+++ b/modules/local/pyopenms/flaginsource/main.nf
@@ -1,0 +1,39 @@
+process PYOPENMS_FLAGINSOURCE {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/pyopenms:3.4.1--py312h6b06db6_2' :
+        'biocontainers/pyopenms:3.4.1--py312h6b06db6_2' }"
+
+    input:
+    tuple val(meta), path(fdr_filtered), path(rescored)
+
+    output:
+    tuple val(meta), path("*_insource_filtered.idXML"), emit: idxml
+    tuple val(meta), path("*_insource_rescored.idXML"), emit: rescored_idxml
+    tuple val("${task.process}"), val('pyopenms'), eval("pip show pyopenms | grep Version | sed 's/Version: //'"), topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args   = task.ext.args   ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    flag_in_source_fragments.py \\
+        --filtered $fdr_filtered \\
+        --rescored $rescored \\
+        --out ${prefix}_insource_filtered.idXML \\
+        --out-rescored ${prefix}_insource_rescored.idXML \\
+        $args
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}_insource_filtered.idXML
+    touch ${prefix}_insource_rescored.idXML
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,6 +61,7 @@ params {
     fdr_level                       = 'peptide_level_fdrs'
     subset_max_train                = 0
     global_fdr                      = false
+    flag_in_source                  = false
 
     // IDfilter settings
     peptide_min_length              = 8

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -331,6 +331,13 @@
                     "fa_icon": "fas fa-less-than",
                     "description": "Compute global FDR and backfilter sample-specific FDRs"
                 },
+                "flag_in_source": {
+                    "type": "boolean",
+                    "default": false,
+                    "fa_icon": "fas fa-tags",
+                    "description": "Flag in-source fragments and re-inject them into the FDR-filtered set for quantification",
+                    "help_text": "When enabled, after rescoring the pipeline flags in-source dissociation fragments among the 100% FDR PSMs using the FDR-filtered peptides as parents (a fragment co-elutes with its parent in observed RT but DeepLC predicts a different RT). Each PeptideHit is tagged with an `is_isf` UserParam, and the flagged fragments are appended to the FDR-filtered idXML so their signal reaches quantification. The `is_isf` flag is exported to the final TSV."
+                },
 
                 "subset_max_train": {
                     "type": "integer",

--- a/subworkflows/local/rescore/main.nf
+++ b/subworkflows/local/rescore/main.nf
@@ -91,21 +91,8 @@ workflow RESCORE {
         }
     }
 
-    // Optionally flag in-source fragments and re-inject the flagged candidates into the
-    // FDR-filtered set so they reach quantification (parents = the FDR-filtered hits,
-    // candidates = the 100% FDR rescored runs). The augmented idXML replaces fdr_filtered.
-    if (params.flag_in_source) {
-        ch_flag_in_source = ch_filter_q_value
-            .map { meta, file -> [meta.id, meta, file] }
-            .join(ch_rescored_runs.map { meta, file -> [meta.id, file] }, by: 0)
-            .map { id, meta, filtered, rescored -> [meta, filtered, rescored] }
-        PYOPENMS_FLAGINSOURCE(ch_flag_in_source)
-        // Augmented filtered (whitelist + ID export) replaces fdr_filtered; the is_isf-annotated
-        // rescored runs replace rescored_runs so the flag survives into quantification.
-        ch_filter_q_value = PYOPENMS_FLAGINSOURCE.out.idxml
-        ch_rescored_runs  = PYOPENMS_FLAGINSOURCE.out.rescored_idxml
-    }
-
+    // Branch the FDR-filtered runs FIRST so empty samples (no peptides passing FDR) are diverted
+    // before any flagging, regardless of --flag_in_source.
     ch_filter_q_value
         .map { meta, file -> [[id: meta.id], file] }
         .branch {
@@ -115,9 +102,43 @@ workflow RESCORE {
         }
         .set { ch_fdr_branched }
 
+    // Optionally flag in-source fragments and re-inject the flagged candidates into the
+    // FDR-filtered set so they reach quantification (parents = the FDR-filtered hits, candidates
+    // = the 100% FDR rescored runs). Only non-empty samples are flagged; the augmented filtered
+    // replaces fdr_filtered and the is_isf-annotated rescored runs replace rescored_runs so the
+    // flag survives into quantification.
+    if (params.flag_in_source && params.global_fdr) {
+        log.warn("'--flag_in_source' is not supported together with '--global_fdr' and will be skipped.")
+    }
+
+    if (params.flag_in_source && !params.global_fdr) {
+        PYOPENMS_FLAGINSOURCE(
+            ch_fdr_branched.non_empty
+                .map { meta, file -> [meta.id, meta, file] }
+                .join(ch_rescored_runs.map { meta, file -> [meta.id, file] }, by: 0)
+                .map { id, meta, filtered, rescored -> [meta, filtered, rescored] }
+        )
+        // Re-branch the augmented filtered (defensive; appended ISF keep it non-empty).
+        PYOPENMS_FLAGINSOURCE.out.idxml
+            .map { meta, file -> [[id: meta.id], file] }
+            .branch {
+                non_empty: it[1].countLines() > 130
+                empty:     true
+            }
+            .set { ch_fdr_flagged }
+
+        ch_fdr_filtered       = ch_fdr_flagged.non_empty
+        ch_fdr_filtered_empty = ch_fdr_branched.empty.mix(ch_fdr_flagged.empty)
+        ch_rescored_runs      = PYOPENMS_FLAGINSOURCE.out.rescored_idxml
+    }
+    else {
+        ch_fdr_filtered       = ch_fdr_branched.non_empty
+        ch_fdr_filtered_empty = ch_fdr_branched.empty
+    }
+
     emit:
     rescored_runs      = ch_rescored_runs.map { meta, file -> [[id: meta.id], file] }
-    fdr_filtered       = ch_fdr_branched.non_empty
-    fdr_filtered_empty = ch_fdr_branched.empty
+    fdr_filtered       = ch_fdr_filtered
+    fdr_filtered_empty = ch_fdr_filtered_empty
     multiqc_files      = ch_multiqc_files
 }

--- a/subworkflows/local/rescore/main.nf
+++ b/subworkflows/local/rescore/main.nf
@@ -13,6 +13,7 @@ include {
     OPENMS_PERCOLATORADAPTER as OPENMS_PERCOLATORADAPTER_GLOBAL
 } from '../../../modules/local/openmsthirdparty/percolatoradapter'
 include { OPENMS_TEXTEXPORTER as OPENMS_TEXTEXPORTER_GLOBAL           } from '../../../modules/nf-core/openms/textexporter/main'
+include { PYOPENMS_FLAGINSOURCE                                       } from '../../../modules/local/pyopenms/flaginsource'
 //
 // MODULE: Installed directly from nf-core/modules
 //
@@ -88,6 +89,21 @@ workflow RESCORE {
             OPENMS_IDFILTER_Q_VALUE(ch_rescored_runs.map { group_meta, idxml -> [group_meta, idxml, []] })
             ch_filter_q_value = OPENMS_IDFILTER_Q_VALUE.out.filtered
         }
+    }
+
+    // Optionally flag in-source fragments and re-inject the flagged candidates into the
+    // FDR-filtered set so they reach quantification (parents = the FDR-filtered hits,
+    // candidates = the 100% FDR rescored runs). The augmented idXML replaces fdr_filtered.
+    if (params.flag_in_source) {
+        ch_flag_in_source = ch_filter_q_value
+            .map { meta, file -> [meta.id, meta, file] }
+            .join(ch_rescored_runs.map { meta, file -> [meta.id, file] }, by: 0)
+            .map { id, meta, filtered, rescored -> [meta, filtered, rescored] }
+        PYOPENMS_FLAGINSOURCE(ch_flag_in_source)
+        // Augmented filtered (whitelist + ID export) replaces fdr_filtered; the is_isf-annotated
+        // rescored runs replace rescored_runs so the flag survives into quantification.
+        ch_filter_q_value = PYOPENMS_FLAGINSOURCE.out.idxml
+        ch_rescored_runs  = PYOPENMS_FLAGINSOURCE.out.rescored_idxml
     }
 
     ch_filter_q_value

--- a/tests/flag_in_source.nf.test
+++ b/tests/flag_in_source.nf.test
@@ -1,0 +1,46 @@
+nextflow_pipeline {
+
+    name "Test pipeline with in-source fragment flagging"
+    script "../main.nf"
+    tag "pipeline"
+
+    test("-profile test --flag_in_source") {
+
+        when {
+            params {
+                outdir         = "$outputDir"
+                flag_in_source = true
+            }
+        }
+
+        then {
+            assert workflow.success
+
+            // The is_isf flag must reach the final per-peptidoform TSV(s).
+            def tsvs_with_peptidoform = []
+            def tsvs_with_is_isf = []
+            new File(params.outdir).eachFileRecurse { file ->
+                if (file.name.endsWith('.tsv')) {
+                    def lines = file.readLines()
+                    if (lines.size() > 0) {
+                        def header = lines[0].split('\t') as List
+                        if (header.contains('peptidoform')) {
+                            tsvs_with_peptidoform.add(file.name)
+                            if (header.contains('is_isf')) {
+                                tsvs_with_is_isf.add(file.name)
+                            }
+                        }
+                    }
+                }
+            }
+
+            assertAll(
+                { assert workflow.success },
+                // at least one result TSV was produced
+                { assert tsvs_with_peptidoform.size() > 0 },
+                // every result TSV carries the is_isf column when flagging is enabled
+                { assert tsvs_with_is_isf.size() == tsvs_with_peptidoform.size() }
+            )
+        }
+    }
+}

--- a/tests/flag_in_source.nf.test
+++ b/tests/flag_in_source.nf.test
@@ -14,8 +14,6 @@ nextflow_pipeline {
         }
 
         then {
-            assert workflow.success
-
             // The is_isf flag must reach the final per-peptidoform TSV(s).
             def tsvs_with_peptidoform = []
             def tsvs_with_is_isf = []
@@ -36,6 +34,10 @@ nextflow_pipeline {
 
             assertAll(
                 { assert workflow.success },
+                { assert snapshot(
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_mhcquant_software_mqc_versions.yml")
+                ).match() },
                 // at least one result TSV was produced
                 { assert tsvs_with_peptidoform.size() > 0 },
                 // every result TSV carries the is_isf column when flagging is enabled

--- a/tests/flag_in_source.nf.test.snap
+++ b/tests/flag_in_source.nf.test.snap
@@ -1,0 +1,57 @@
+{
+    "-profile test --flag_in_source": {
+        "content": [
+            {
+                "MS2RESCORE": {
+                    "MS2Rescore": "3.1.5"
+                },
+                "OPENMSTHIRDPARTY_COMETADAPTER": {
+                    "Comet": "2024.01 rev. 1",
+                    "CometAdapter": "3.5.0"
+                },
+                "OPENMS_DECOYDATABASE": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDFILTER_Q_VALUE": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_IDMASSACCURACY": {
+                    "openms": "3.4.1"
+                },
+                "OPENMS_IDMERGER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_PEPTIDEINDEXER": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_PERCOLATORADAPTER": {
+                    "PercolatorAdapter": "3.5.0-pre-exported-20251212",
+                    "percolator": "3.07.1"
+                },
+                "OPENMS_PSMFEATUREEXTRACTOR": {
+                    "openms": "3.5.0"
+                },
+                "OPENMS_TEXTEXPORTER": {
+                    "openms": "3.5.0"
+                },
+                "PYOPENMS_CHROMATOGRAMEXTRACTOR": {
+                    "pyopenms": "3.4.1"
+                },
+                "PYOPENMS_FLAGINSOURCE": {
+                    "pyopenms": "3.4.1"
+                },
+                "SUMMARIZE_RESULTS": {
+                    "pyopenms": "3.4.1"
+                },
+                "Workflow": {
+                    "nf-core/mhcquant": "v3.2.0"
+                }
+            }
+        ],
+        "timestamp": "2026-06-09T12:53:02.498497411",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.5"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds `--flag_in_source` (default `false`). After rescoring, flags in-source fragments among the 100% FDR PSMs using the FDR-filtered peptides as parents (strict per-run co-elution in observed RT + DeepLC RT-prediction mismatch), tags every PeptideHit with an `is_isf` UserParam, and re-injects the flagged fragments into the FDR-filtered set so their signal reaches quantification. `is_isf` is exported to the final TSV.

New module `PYOPENMS_FLAGINSOURCE` (`bin/flag_in_source_fragments.py`); when the flag is off, behaviour is unchanged.

> Depends on #460 (QUANT groupKey `combine` fix) for end-to-end quantification.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] `CHANGELOG.md` is updated.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
